### PR TITLE
app.mk: Fix ping command args for macOS

### DIFF
--- a/getting started/makefile/app.mk
+++ b/getting started/makefile/app.mk
@@ -134,6 +134,9 @@ endif
 ifeq ($(HOST_OS),cygwin)
 	# This assumes that the Windows ping command is used, not cygwin's.
 	QUICK_PING_ARGS = -n 1 -w 1000
+else ifeq($(HOST_OS),macos)
+        # macOS ping command uses -W to specify the timeout
+        QUICK_PING_ARGS = -c 1 -W 1000
 else # Linux
 	QUICK_PING_ARGS = -c 1 -w 1
 endif


### PR DESCRIPTION
Unlike Linux, the macOS ping command uses `-W` to specify the ping timeout. This patch adds an additional check for host-os equal to macOS and uses the correct arguments for the ping command on macOS.