### PR TITLE
Only use variant for ad tracking, return HLS master manifest for video playback

### DIFF
--- a/advertising/rsgadb/lib/rafxssai.brs
+++ b/advertising/rsgadb/lib/rafxssai.brs
@@ -866,8 +866,8 @@ end if
 end if
 end function
 impl.onPosition = function (msg as object) as void
-if invalid <> m.prplyInfo["mediaURL"] and invalid = m.prplyInfo["pods"]
-adjsn = m.loader.requestAdInsertion(m.prplyInfo.mediaURL)
+if invalid <> m.prplyInfo["variantURL"] and invalid = m.prplyInfo["pods"]
+adjsn = m.loader.requestAdInsertion(m.prplyInfo.variantURL)
 if invalid = adjsn
 m.prplyInfo["pods"] = []
 else
@@ -894,9 +894,10 @@ if invalid = masterjson or not m.isValidString(masterjson["Master-M3U8"]) then r
 if false then return {masterURL:masterjson["Master-M3U8"]}
 playlistUrl = masterjson["Master-M3U8"]
 mediaURL = m.selectMediaUrl(playlistUrl, requestObj)
-if "" <> mediaURL
-prplyInfo["mediaURL"] = mediaURL
+if mediaURL <> ""
+prplyInfo["variantURL"] = mediaURL
 end if
+prplyInfo["mediaURL"] = playlistUrl
 matches = m.trckngpos.match(requestObj.url)
 if 1 < matches.count()
 m.trackingposition = matches[1]
@@ -1421,7 +1422,7 @@ function RAFX_SSAI(params as object) as object
         else if "simple" = params["trackingmode"]'
             p = RAFX_getAdobeSimplePlugin(params)'
         end if
-        p["__version__"] = "0b.42.35.15"
+        p["__version__"] = "0b.42.36.15"
         p["__name__"] = params["name"]
         return p
     end if


### PR DESCRIPTION
When using simple adapter for VOD playback, the returned "playURL" was a single variant of the master manifest, and thus would lose captions information and the ability to switch variants based on network speed. 

The variant is still needed to track the ad, but the video node should still get the master playlist for HLS to work correctly. 

I also bumped the version number to indicate a change. 

@LockChristian @smathairoku is there a reason the library doesn't have indentation? It is very hard to read without any formatting. Could I open a PR with the file formatted (using the VS-code extension formatter)?