### PR TITLE
Remove unused <output-prefix> parameter and update usage message

### DIFF
--- a/media/TrickPlayThumbnailsDASH/run_scripts_dash.sh
+++ b/media/TrickPlayThumbnailsDASH/run_scripts_dash.sh
@@ -7,7 +7,7 @@
 # a .mpd manifest with thumbnails
 
 if [ $# -lt 6 ]; then
-	echo "Usage: $0 <input-file> <output-dir> <output-prefix> <resolution> <columns> <rows> <interval>"
+	echo "Usage: $0 <input-file> <output-dir> <resolution> <columns> <rows> <interval>"
 	exit 1
 fi
 


### PR DESCRIPTION
This commit removes the <output-prefix> parameter from the script and updates the usage message accordingly. The <output-prefix> parameter was not being used, so it's being cleaned up to improve code clarity and maintainability.